### PR TITLE
Add n8n integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# mcp-installer - A MCP Server to install MCP Servers
+# mcp-installer - A MCP Server to install MCP Servers (with n8n support)
 
-This server is a server that installs other MCP servers for you. Install it, and you can ask Claude to install MCP servers hosted in npm or PyPi for you. Requires `npx` and `uv` to be installed for node and Python servers respectively.
+This server is a server that installs other MCP servers for you. Install it, and you can ask Claude to install MCP servers hosted in npm or PyPi for you. It also provides special support for installing and configuring n8n servers.
+
+Requires `npx` and `uv` to be installed for node and Python servers respectively.
 
 ![image](https://github.com/user-attachments/assets/d082e614-b4bc-485c-a7c5-f80680348793)
 
@@ -28,3 +30,18 @@ Put this into your `claude_desktop_config.json` (either at `~/Library/Applicatio
 > Hi Claude, please install the MCP server at /Users/anibetts/code/mcp-youtube, I'm too lazy to do it myself.
 
 > Install the server @modelcontextprotocol/server-github. Set the environment variable GITHUB_PERSONAL_ACCESS_TOKEN to '1234567890'
+
+### n8n Integration
+
+This fork adds special support for n8n:
+
+> Install and configure n8n as an MCP server. Generate credentials for my API endpoints
+
+> Set up an n8n server with the packages: 'n8n-nodes-clickup, n8n-nodes-aws'
+
+The installer will:
+
+1. Install n8n and additional requested packages
+2. Configure n8n as an MCP server
+3. Generate credentials for API access
+4. Provide console output with configuration details

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-installer - A MCP Server to install MCP Servers (with n8n support)
 
-This server is a server that installs other MCP servers for you. Install it, and you can ask Claude to install MCP servers hosted in npm or PyPi for you. It also provides special support for installing and configuring n8n servers.
+This server is a server that installs other MCP servers for you. Install it, and you can ask Claude to install MCP servers hosted in npm or PyPi for you. It also provides special support for n8n integration.
 
 Requires `npx` and `uv` to be installed for node and Python servers respectively.
 
@@ -33,15 +33,113 @@ Put this into your `claude_desktop_config.json` (either at `~/Library/Applicatio
 
 ### n8n Integration
 
-This fork adds special support for n8n:
+This fork adds special support for integrating MCP servers with n8n:
 
-> Install and configure n8n as an MCP server. Generate credentials for my API endpoints
+```
+Install hyperbrowser-mcp MCP server for n8n integration
 
-> Set up an n8n server with the packages: 'n8n-nodes-clickup, n8n-nodes-aws'
+Install the MCP server @modelcontextprotocol/server-filesystem for n8n with arguments ['/path/to/directory']
+
+Install the local MCP server at /path/to/local/mcp-server for n8n integration with credential name "My Custom MCP Server"
+```
 
 The installer will:
 
-1. Install n8n and additional requested packages
-2. Configure n8n as an MCP server
-3. Generate credentials for API access
-4. Provide console output with configuration details
+1. Install the MCP server in the appropriate location for n8n access
+2. Install n8n-nodes-mcp if not already installed
+3. Generate n8n credential configuration in the format needed for the MCP Client node
+4. Output two example n8n workflow nodes:
+   - A "List Tools" node that lists all tools from the MCP server
+   - An "Execute Tool" node that can execute any tool from the server
+5. Save configuration to a file in `.mcp-n8n-configs/` for future reference
+
+#### Usage in n8n:
+
+1. After installing an MCP server with this tool, copy the credential configuration from the output
+2. In n8n, create a new credential of type "MCP Client API" and paste the copied configuration
+3. Create a new workflow and add a "MCP Client Tool" node
+4. Configure the node to use the credential you created
+5. Choose either to list available tools or execute a specific tool
+
+The credential format will look something like:
+
+```json
+{
+  "id": "uniqueId",
+  "name": "Server Name MCP",
+  "data": {
+    "command": "npx",
+    "args": ["package-name"],
+    "env": {}
+  },
+  "type": "mcpClientApi"
+}
+```
+
+#### Example Workflow Nodes
+
+The installer generates two sample workflow nodes that you can import into n8n:
+
+1. **List Tools Node**: Lists all available tools from the MCP server
+```json
+{
+  "nodes": [
+    {
+      "parameters": {},
+      "type": "n8n-nodes-mcp.mcpClientTool",
+      "typeVersion": 1,
+      "position": [580, 700],
+      "credentials": {
+        "mcpClientApi": {
+          "id": "credentialId",
+          "name": "Server MCP"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "MCP Client Server Tools": {
+      "ai_tool": [[]]
+    }
+  }
+}
+```
+
+2. **Execute Tool Node**: Executes a specific tool from the MCP server
+```json
+{
+  "nodes": [
+    {
+      "parameters": {
+        "operation": "executeTool",
+        "toolName": "={{ $fromAI(\"tool\",\"Set this with specific tool name\") }}",
+        "toolParameters": "={{ $fromAI('Tool_Parameters', '', 'json') }}"
+      },
+      "type": "n8n-nodes-mcp.mcpClientTool",
+      "typeVersion": 1,
+      "position": [620, 740],
+      "credentials": {
+        "mcpClientApi": {
+          "id": "credentialId",
+          "name": "Server MCP"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Server Tools Execute": {
+      "ai_tool": [[]]
+    }
+  }
+}
+```
+
+### Requirements
+
+To use the n8n integration:
+
+1. n8n must be installed on your system (`npm install -g n8n`)
+2. The n8n-nodes-mcp package must be installed (`npm install -g n8n-nodes-mcp`)
+3. The MCP server you're installing must be accessible to n8n
+
+For more information about using MCP servers with n8n, see the [n8n-nodes-mcp documentation](https://github.com/nerding-io/n8n-nodes-mcp).

--- a/package.json
+++ b/package.json
@@ -14,12 +14,9 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.1",
     "rimraf": "^6.0.1",
-    "spawn-rx": "^4.0.0",
-    "n8n": "^1.29.1",
-    "crypto-js": "^4.2.0"
+    "spawn-rx": "^4.0.0"
   },
   "devDependencies": {
-    "@types/crypto-js": "^4.2.2",
     "shx": "^0.3.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@anaisbetts/mcp-installer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "bin": {
     "mcp-installer": "./lib/index.mjs"
   },
-  "description": "A MCP server to install other MCP servers",
+  "description": "A MCP server to install other MCP servers, with n8n integration support",
   "main": "index.js",
   "scripts": {
     "prepare": "tsc && shx chmod +x ./lib/index.mjs"
@@ -14,9 +14,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.1",
     "rimraf": "^6.0.1",
-    "spawn-rx": "^4.0.0"
+    "spawn-rx": "^4.0.0",
+    "n8n": "^1.29.1",
+    "crypto-js": "^4.2.0"
   },
   "devDependencies": {
+    "@types/crypto-js": "^4.2.2",
     "shx": "^0.3.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "spawn-rx": "^4.0.0"
   },
   "devDependencies": {
+    "@types/node": "^20.9.0",
     "shx": "^0.3.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"

--- a/src/index.mts
+++ b/src/index.mts
@@ -10,11 +10,12 @@ import * as os from "os";
 import * as fs from "fs";
 import * as path from "path";
 import { spawnPromise } from "spawn-rx";
+import * as crypto from "crypto";
 
 const server = new Server(
   {
     name: "mcp-installer",
-    version: "0.5.0",
+    version: "0.6.0",
   },
   {
     capabilities: {
@@ -72,6 +73,66 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               items: { type: "string" },
               description: "The environment variables to set, delimited by =",
             },
+          },
+          required: ["path"],
+        },
+      },
+      {
+        name: "install_repo_mcp_server_for_n8n",
+        description: "Install an MCP server via npx or uvx for n8n integration",
+        inputSchema: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "The package name of the MCP server",
+            },
+            args: {
+              type: "array",
+              items: { type: "string" },
+              description: "The arguments to pass along",
+            },
+            env: {
+              type: "array",
+              items: { type: "string" },
+              description: "The environment variables to set, delimited by =",
+            },
+            credentialName: {
+              type: "string",
+              description: "Name for the n8n credential",
+              default: "MCP Server"
+            }
+          },
+          required: ["name"],
+        },
+      },
+      {
+        name: "install_local_mcp_server_for_n8n",
+        description:
+          "Install an MCP server whose code is cloned locally on your computer for n8n integration",
+        inputSchema: {
+          type: "object",
+          properties: {
+            path: {
+              type: "string",
+              description:
+                "The path to the MCP server code cloned on your computer",
+            },
+            args: {
+              type: "array",
+              items: { type: "string" },
+              description: "The arguments to pass along",
+            },
+            env: {
+              type: "array",
+              items: { type: "string" },
+              description: "The environment variables to set, delimited by =",
+            },
+            credentialName: {
+              type: "string",
+              description: "Name for the n8n credential",
+              default: "MCP Server"
+            }
           },
           required: ["path"],
         },
@@ -163,7 +224,7 @@ function installRepoWithArgsToClaudeDesktop(
   env?: string[]
 ) {
   // If the name is in a scoped package, we need to remove the scope
-  const serverName = /^@.*\//i.test(name) ? name.split("/")[1] : name;
+  const serverName = /^@.*\\//i.test(name) ? name.split("/")[1] : name;
 
   installToClaudeDesktop(
     serverName,
@@ -171,6 +232,168 @@ function installRepoWithArgsToClaudeDesktop(
     [name, ...(args ?? [])],
     env
   );
+}
+
+// Find n8n node modules directory
+async function findN8nModulesDir() {
+  try {
+    // Check for local n8n installation
+    const { stdout: n8nPath } = await spawnPromise("which", ["n8n"]);
+    
+    if (n8nPath) {
+      // Get n8n installation directory
+      const n8nDir = path.dirname(path.dirname(n8nPath.trim()));
+      
+      // Check for node_modules in the n8n directory
+      const nodeModulesPath = path.join(n8nDir, "node_modules");
+      
+      if (fs.existsSync(nodeModulesPath)) {
+        return nodeModulesPath;
+      }
+    }
+    
+    // Fallback to global node_modules
+    const { stdout: npmRoot } = await spawnPromise("npm", ["root", "-g"]);
+    return npmRoot.trim();
+  } catch (error) {
+    console.error("Error finding n8n modules directory:", error);
+    // Fallback to global npm root
+    try {
+      const { stdout: npmRoot } = await spawnPromise("npm", ["root", "-g"]);
+      return npmRoot.trim();
+    } catch (e) {
+      // Ultimate fallback for common global node_modules locations
+      if (process.platform === "win32") {
+        return path.join(process.env.APPDATA, "npm", "node_modules");
+      } else {
+        return path.join("/usr", "local", "lib", "node_modules");
+      }
+    }
+  }
+}
+
+function generateCredentialId() {
+  return crypto.randomBytes(8).toString('hex');
+}
+
+// Generate n8n credential configuration
+function generateN8nCredential(serverName, command, args, env, credentialName) {
+  // Clean up the server name for credential naming
+  const cleanServerName = serverName.replace(/^@/, '').replace(/\//, '-');
+  
+  // Create environment object
+  const envObj = (env ?? []).reduce((acc, val) => {
+    const [key, value] = val.split("=");
+    acc[key] = value;
+    return acc;
+  }, {});
+  
+  // Generate a unique credential ID
+  const credentialId = generateCredentialId();
+  
+  // Create credential object
+  const credential = {
+    id: credentialId,
+    name: credentialName || `${cleanServerName} MCP`,
+    data: {
+      command: command,
+      args: args || [],
+      env: envObj
+    },
+    type: "mcpClientApi"
+  };
+  
+  // Create example MCP List Tools node
+  const listToolsNode = {
+    nodes: [
+      {
+        parameters: {},
+        type: "n8n-nodes-mcp.mcpClientTool",
+        typeVersion: 1,
+        position: [580, 700],
+        id: crypto.randomBytes(16).toString('hex'),
+        name: `MCP Client ${cleanServerName} Tools`,
+        credentials: {
+          mcpClientApi: {
+            id: credentialId,
+            name: credential.name
+          }
+        }
+      }
+    ],
+    connections: {},
+    pinData: {},
+    meta: {
+      templateCredsSetupCompleted: true,
+      instanceId: crypto.randomBytes(32).toString('hex')
+    }
+  };
+  
+  // Default to first connection being empty array
+  listToolsNode.connections[`MCP Client ${cleanServerName} Tools`] = {
+    ai_tool: [[]]
+  };
+  
+  // Create example MCP Execute Tool node
+  const executeToolNode = {
+    nodes: [
+      {
+        parameters: {
+          operation: "executeTool",
+          toolName: "={{ $fromAI(\"tool\",\"Set this with specific tool name\") }}",
+          toolParameters: "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Tool_Parameters', ``, 'json') }}"
+        },
+        type: "n8n-nodes-mcp.mcpClientTool",
+        typeVersion: 1,
+        position: [620, 740],
+        id: crypto.randomBytes(16).toString('hex'),
+        name: `${cleanServerName} Tools Execute`,
+        credentials: {
+          mcpClientApi: {
+            id: credentialId,
+            name: credential.name
+          }
+        }
+      }
+    ],
+    connections: {},
+    pinData: {},
+    meta: {
+      templateCredsSetupCompleted: true,
+      instanceId: crypto.randomBytes(32).toString('hex')
+    }
+  };
+  
+  // Default to first connection being empty array
+  executeToolNode.connections[`${cleanServerName} Tools Execute`] = {
+    ai_tool: [[]]
+  };
+  
+  return {
+    credential,
+    listToolsNode,
+    executeToolNode
+  };
+}
+
+// Save credential config to a file
+function saveCredentialConfig(configObj, serverName) {
+  const homeDir = os.homedir();
+  const configDir = path.join(homeDir, '.mcp-n8n-configs');
+  
+  // Create directory if it doesn't exist
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true });
+  }
+  
+  // Clean up server name for filename
+  const cleanServerName = serverName.replace(/[@/]/g, '-');
+  const configPath = path.join(configDir, `${cleanServerName}-config.json`);
+  
+  // Write config to file
+  fs.writeFileSync(configPath, JSON.stringify(configObj, null, 2));
+  
+  return configPath;
 }
 
 async function attemptNodeInstall(
@@ -195,6 +418,244 @@ async function attemptNodeInstall(
   }
 
   return {};
+}
+
+async function installRepoMcpServerForN8n(name, args, env, credentialName) {
+  if (!(await hasNodeJs())) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Node.js is not installed, please install it!`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  // Find n8n node_modules directory
+  const n8nModulesDir = await findN8nModulesDir();
+  console.log(`Using n8n modules directory: ${n8nModulesDir}`);
+
+  let command, installCommand, args2;
+  
+  if (await isNpmPackage(name)) {
+    console.log(`Installing ${name} via npm...`);
+    command = "npx";
+    installCommand = "npm";
+    args2 = ["install", "-g", name];
+  } else {
+    if (!(await hasUvx())) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Python uv is not installed, please install it! Tell users to go to https://docs.astral.sh/uv`,
+          },
+        ],
+        isError: true,
+      };
+    }
+    
+    console.log(`Installing ${name} via uvx...`);
+    command = "uvx";
+    installCommand = "uv";
+    args2 = ["pip", "install", name];
+  }
+
+  try {
+    // Install the package
+    console.log(`Running: ${installCommand} ${args2.join(' ')}`);
+    await spawnPromise(installCommand, args2);
+    
+    // Also install n8n-nodes-mcp if not installed
+    try {
+      await spawnPromise("npm", ["list", "-g", "n8n-nodes-mcp"]);
+    } catch (e) {
+      console.log("Installing n8n-nodes-mcp...");
+      await spawnPromise("npm", ["install", "-g", "n8n-nodes-mcp"]);
+    }
+    
+    // Generate n8n credential configuration
+    const configObj = generateN8nCredential(
+      name,
+      command,
+      [name, ...(args ?? [])],
+      env,
+      credentialName
+    );
+    
+    // Save configuration to file
+    const configPath = saveCredentialConfig(configObj, name);
+    
+    // Format the output for better console display
+    const credentialOutput = JSON.stringify(configObj.credential, null, 2);
+    const listToolsOutput = JSON.stringify(configObj.listToolsNode, null, 2);
+    const executeToolOutput = JSON.stringify(configObj.executeToolNode, null, 2);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `
+MCP server ${name} installed successfully for n8n integration!
+
+1. Add this credential in n8n:
+${credentialOutput}
+
+2. Use this JSON for List Tools workflow:
+${listToolsOutput}
+
+3. Use this JSON for Execute Tool workflow:
+${executeToolOutput}
+
+Configuration saved to: ${configPath}
+
+To use this MCP server in n8n:
+1. Create a new credential in n8n of type "MCP Client API"
+2. Use the configuration above
+3. Create workflows using the MCP Client Tool node
+`,
+        },
+      ],
+    };
+  } catch (err) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error installing ${name}: ${err}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+async function installLocalMcpServerForN8n(dirPath, args, env, credentialName) {
+  if (!fs.existsSync(dirPath)) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Path ${dirPath} does not exist locally!`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const n8nModulesDir = await findN8nModulesDir();
+  console.log(`Using n8n modules directory: ${n8nModulesDir}`);
+
+  try {
+    // Also install n8n-nodes-mcp if not installed
+    try {
+      await spawnPromise("npm", ["list", "-g", "n8n-nodes-mcp"]);
+    } catch (e) {
+      console.log("Installing n8n-nodes-mcp...");
+      await spawnPromise("npm", ["install", "-g", "n8n-nodes-mcp"]);
+    }
+  } catch (e) {
+    console.error("Error checking/installing n8n-nodes-mcp:", e);
+  }
+
+  if (fs.existsSync(path.join(dirPath, "package.json"))) {
+    try {
+      // Read package.json to get the name
+      const packageJson = JSON.parse(
+        fs.readFileSync(path.join(dirPath, "package.json"), "utf-8")
+      );
+      
+      const serverName = packageJson.name || path.basename(dirPath);
+      
+      // Install dependencies
+      console.log(`Installing dependencies for ${dirPath}...`);
+      await spawnPromise("npm", ["install"], { cwd: dirPath });
+      
+      // Determine the binary path
+      let command = "node";
+      let binArgs = [];
+      
+      if (packageJson.bin) {
+        // For npm package with binary
+        const binName = Object.keys(packageJson.bin)[0];
+        const binPath = path.resolve(dirPath, packageJson.bin[binName]);
+        binArgs = [binPath, ...(args ?? [])];
+      } else if (packageJson.main) {
+        // For npm package with main entry
+        const mainPath = path.resolve(dirPath, packageJson.main);
+        binArgs = [mainPath, ...(args ?? [])];
+      } else {
+        // Fallback
+        binArgs = [path.join(dirPath, "index.js"), ...(args ?? [])];
+      }
+      
+      // Generate n8n credential configuration
+      const configObj = generateN8nCredential(
+        serverName,
+        command,
+        binArgs,
+        env,
+        credentialName
+      );
+      
+      // Save configuration to file
+      const configPath = saveCredentialConfig(configObj, serverName);
+      
+      // Format the output for better console display
+      const credentialOutput = JSON.stringify(configObj.credential, null, 2);
+      const listToolsOutput = JSON.stringify(configObj.listToolsNode, null, 2);
+      const executeToolOutput = JSON.stringify(configObj.executeToolNode, null, 2);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `
+Local MCP server ${serverName} installed successfully for n8n integration!
+
+1. Add this credential in n8n:
+${credentialOutput}
+
+2. Use this JSON for List Tools workflow:
+${listToolsOutput}
+
+3. Use this JSON for Execute Tool workflow:
+${executeToolOutput}
+
+Configuration saved to: ${configPath}
+
+To use this MCP server in n8n:
+1. Create a new credential in n8n of type "MCP Client API"
+2. Use the configuration above
+3. Create workflows using the MCP Client Tool node
+`,
+          },
+        ],
+      };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error installing local MCP server: ${err}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Can't figure out how to install ${dirPath}. No package.json found.`,
+      },
+    ],
+    isError: true,
+  };
 }
 
 async function installLocalMcpServer(
@@ -323,6 +784,28 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       };
 
       return await installLocalMcpServer(dirPath, args, env);
+    }
+    
+    if (request.params.name === "install_repo_mcp_server_for_n8n") {
+      const { name, args, env, credentialName } = request.params.arguments as {
+        name: string;
+        args?: string[];
+        env?: string[];
+        credentialName?: string;
+      };
+
+      return await installRepoMcpServerForN8n(name, args, env, credentialName);
+    }
+
+    if (request.params.name === "install_local_mcp_server_for_n8n") {
+      const dirPath = request.params.arguments!.path as string;
+      const { args, env, credentialName } = request.params.arguments as {
+        args?: string[];
+        env?: string[];
+        credentialName?: string;
+      };
+
+      return await installLocalMcpServerForN8n(dirPath, args, env, credentialName);
     }
 
     throw new Error(`Unknown tool: ${request.params.name}`);


### PR DESCRIPTION
This PR adds n8n integration support to the MCP installer. The changes include:

1. Added two new tools for installing MCP servers specifically for n8n integration:
   - `install_repo_mcp_server_for_n8n` - For installing npm or Python packages
   - `install_local_mcp_server_for_n8n` - For installing local MCP server repositories

2. Added functionality to:
   - Find the appropriate n8n modules directory
   - Generate n8n credentials in the format required by n8n-nodes-mcp
   - Create example workflow nodes (List Tools and Execute Tool)
   - Save configuration locally for reference
   
3. Updated documentation with detailed instructions for using MCP servers with n8n

These changes allow users to easily install MCP servers and get the necessary configuration to use them within n8n workflows.
